### PR TITLE
Stop filtering out PCB services in kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -22,12 +22,3 @@ bom: hardware/BOM.csv
   # Check out https://github.com/kitspace/1clickBOM#readme for more details
 
 gerbers: hardware/Gerber_PCB/ # A path to your folder of gerbers in case it isn't `gerbers/`.
-
-pcb-services: [aisler, pcbway, oshpark, jlcpcb]
-  # A list of the PCB services you would like to have included on your
-  # page. If left undefined all are included. Otherwise ust be a list of Kitspace
-  # sponsors, possible values are:
-  #      - aisler
-  #      - pcbway
-  #      - oshpark
-  #      - jlcpcb


### PR DESCRIPTION
Hey, PCBGoGo just came on as a sponsor and where wondering why their logo wasn't appearing on your pages. The way you have it now, they don't get included. Open Gamma projects are the only ones using the `pcb-services` key. My plan is to remove this feature unless you have strong objections. 

(A better future feature would be to actually map a PCB services capabilities to what's required for a particular design, this was supposed to be a half-way solution to that but was never used that way.)